### PR TITLE
feat(infra) Setup GitHub OIDC Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,137 @@
+### Description
+
+```mermaid
+graph TD;
+    subgraph GitHub
+        A[GitHub Actions Workflows]
+    end
+
+    subgraph AWS["AWS"]
+        B[Amazon ECR]
+        C[OIDC Provider]
+    end
+
+    A --> |"Push Docker Images"| B
+    A --> |"Authenticate using OIDC"| C
+    C --> |"Exchange Tokens"| A
+  ```
+
+### Tech Stack:
+* **Docker** [ ]
+* **AWS:**
+  * IAM  [ ]
+    * Identity Provider (oidc) [ ]
+  * EKS [ ]
+  * VPC [ ]
+  * Subnet [ ]
+  * Internet Gateway [ ]
+  * RDS [ ]
+  * ECR [ ]
+  * ALB [ ]
+* **CI/CD:**
+  * GitHub Actions [ ]
+
+### Todos:
+* **SetUp development environment:**
+    * Consider using the Cloudposse Geodesic container for easier development. [X]
+        * [Cloudposse Geodesic container](https://github.com/cloudposse/geodesic)
+    * Install inside of the geodesic container some necesary software. [ ]
+        * OpenTofu to avoid dealing with the proprietary HashiCorp license change. [X]
+            * [OpenTofu Installation Guide](https://opentofu.org/docs/intro/install/alpine/)
+            * Already installed by default
+        * Atmos to be able to create applications by just creating yaml blocks. [ ]
+            * [Atmos Installation Guide](https://atmos.tools/install/)
+            * WHY THE FUCK, IT DOESN'T GET INSTALLED.
+    * Set up Cloudposse Atmos inside the `infrastructure` folder. [ ]
+
+* **Setting OIDC for GitHub**:
+  * Configure the 
+  * Create the resources inside of `github-oidc-provider` [ ]
+  * Use the file inside of [github-assume-role-policy.mixin.tf](https://github.com/cloudposse/terraform-aws-components/blob/d12201d0affeffd14e5d47276934cfd4b91c2d15/modules/account-map/modules/team-assume-role-policy/github-assume-role-policy.mixin.tf) to import and create the oidc configurations and grant the ECR role with the necesary permissions to push images to ECR.
+  * Create the resources inside of ecr component.
+  * Test your changes with the `challenge-devops-build.yml` pipeline.
+
+* **Create the infrastructure for the application.** [ ]
+  * (Some of the Terraform code and diagrams were created in one of your repositories) [ ]
+  * VPC Atmos Component [ ]
+    * VPC Atmos Component [ ]
+        * Create subnets: [ ]
+            * Private Subnet: [ ]
+                * For database [ ]
+                * For EKS nodes where the application will live [ ]
+            * Public Subnet: [ ]
+                * For the ALB that will expose the application to the internet [ ]
+            * Create an internet gateway and attach it to the public subnet using route tables. [ ]
+  * EKS Atmos Component [ ]
+    * EKS Cluster [ ]
+    * Node Groups [ ]
+  * parrot-app Atmos Component [ ]
+    * Create RDS database: [ ]
+      * Set those secrets in SSM [ ]
+    * Create an IAM role that allows the pod to CRUD the RDS database [ ]
+  * GitHub OIDC Provicer [ ]
+    * To grant GitHub Actions permission to push images to ECR
+    * Branch: feature/setup-github-oidc-provider
+    * PR: 
+  * ECR Atmos component [ ]
+    * To host the images for the application.
+    * Branch: feature/setup-ecr
+    * PR: 
+  * Datadog Atmos Component: [ ]
+    * Install Datadog Agent inside all the node groups. [ ]
+  * AWS Load Balancer Controller Component: [ ]
+    * Enable applications to create ALBs [ ]
+
+* **Create Pipeline for the Application:** [ ]
+  * Pull-Request Pipeline [ ]
+    * (Description: Responsible for running unit tests on each PR commit.)
+    * Create pull-request pipeline using docker-compose file [X]
+        * Interesting post of using docker-compose to run the tests: 
+            * https://stackoverflow.com/questions/64364989/github-actions-how-to-run-test-inside-container
+            * Branch: feature/create-pipeline-challenge-devops-pull-request
+            * PR: https://github.com/franciscoprin/parrot-project/pull/1
+        * Consider not using docker-compose because test could slowdown due to docker-compose file.
+  * Build Pipeline [ ]
+    * Branch: feature/create-pipeline-challenge-devops-build
+    * PR: feat(cicd) Creating Pipeline challenge-devops-build
+    * Description: Triggered on each new commit to main or when a PR is merged. It builds the container and pushes the image to ECR. [ ]
+  * Deploy Pipeline: [ ]
+    * Branch: feature/create-pipeline-challenge-devops-deploy
+    * PR: ???
+    * Description: Runs when creating a release in the repository. Depending on the release level, the application could be deployed to different environments. [ ]
+
+* **Possible Improvements to the Application:** [ ]
+  * Use Chamber to retrieve SSM environment variables. [ ]
+    * Install Chamber in the Dockerfile. [ ]
+    * Create a new entrypoint to read SSM secrets using Chamber. [ ]
+  * The Docker entrypoint should not be responsible for checking if the database is running.
+    * Branch: feature/docker-entrypoint-skip-db-check
+    * PR: https://github.com/franciscoprin/parrot-project/pull/2
+    * This approach is problematic in non-local environments (e.g., staging and production), where it's preferable for the application to fail if the database is unavailable rather than remaining idle and repeatedly checking.
+    * For local development with Docker Compose, checking the database's availability might make sense since both the application and database are started together, and the database might temporarily be unavailable. However, it’s better to handle this within the Docker Compose configuration rather than modifying the entrypoint, as this logic should not apply to non-production environments.
+  * Automatically create a superuser using environment variables: [ ]
+    * [Automate Django Createsuperuser](https://stackoverflow.com/questions/6244382/how-to-automate-createsuperuser-on-django) [ ]
+  * Ensure health checks can read from the database. [ ]
+  * Output application logs in JSON format for better integration with Datadog. [ ]
+  * Being able to use buildx to have multy platform builds [ ]
+    * [Reference video](https://www.youtube.com/watch?v=9jZTsfby5io)
+
+* **Possible Improvements to the GitHub repository:** [ ]
+  * Create default template for PRs [ ]
+    * Branch: feature/create-default-pull-request-template
+    * PR: ???
+
+
+* **Possible Improvements for Scalability:** [ ]
+  * **RDS:** [ ]
+    * Read Replicas [ ]
+  * **ElastiCache (Redis):** [ ]
+    * For caching responses [ ]
+  * **EKS nodes:** [ ]
+    * Karpenter [ ]
+
+* **Possible Improvements for Availability:** [ ]
+  * **RDS:** [ ]
+    * Multi-AZ deployments for high availability [ ]
+  * **ReplicaSet (Affinity and Anti-Affinity):** [ ]
+    * Distribute containers across different nodes in the EKS cluster [ ]

--- a/infrastructure/components/terraform/github-oidc-provider/README.md
+++ b/infrastructure/components/terraform/github-oidc-provider/README.md
@@ -1,0 +1,4 @@
+Reference:
+* https://github.com/cloudposse/terraform-aws-components/tree/1.474.0/modules/github-oidc-provider
+* https://youtube.com/watch?v=aOoRaVuh8Lc
+* https://dev.to/aws-builders/aws-sso-github-setup-35ld

--- a/infrastructure/components/terraform/github-oidc-provider/context.tf
+++ b/infrastructure/components/terraform/github-oidc-provider/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/infrastructure/components/terraform/github-oidc-provider/main.tf
+++ b/infrastructure/components/terraform/github-oidc-provider/main.tf
@@ -1,0 +1,8 @@
+resource "aws_iam_openid_connect_provider" "oidc" {
+  for_each = module.this.enabled ? toset(["github"]) : []
+
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = var.thumbprint_list
+  tags            = module.this.tags
+}

--- a/infrastructure/components/terraform/github-oidc-provider/outputs.tf
+++ b/infrastructure/components/terraform/github-oidc-provider/outputs.tf
@@ -1,0 +1,4 @@
+output "oidc_provider_arn" {
+  description = "GitHub OIDC provider ARN"
+  value       = one(values(aws_iam_openid_connect_provider.oidc)[*].arn)
+}

--- a/infrastructure/components/terraform/github-oidc-provider/providers.tf
+++ b/infrastructure/components/terraform/github-oidc-provider/providers.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+    region = var.region
+    profile = var.aws_profile_name
+
+    default_tags {
+        tags = module.this.tags
+    }
+}

--- a/infrastructure/components/terraform/github-oidc-provider/scripts/get_github_oidc_thumbprint.sh
+++ b/infrastructure/components/terraform/github-oidc-provider/scripts/get_github_oidc_thumbprint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+########################################################################################################################
+# This script downloads the certificate information from $GITHUB_OIDC_HOST, extracts the certificate material, then uses
+# the openssl command to calculate the thumbprint. It is meant to be called manually and the output used to populate
+# the `thumbprint_list` variable in the terraform configuration for this module.
+#
+# This script will pull one of two thumbprints. There are two possible intermediary certificates for the Actions SSL
+# certificate and either can be returned by the GitHub servers, requiring customers to trust both. This is a known
+# behavior when the intermediary certificates are cross-signed by the CA. Therefore, run this script until both values
+# are retrieved.
+#
+# For more, see https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
+########################################################################################################################
+GITHUB_OIDC_HOST="token.actions.githubusercontent.com"
+THUMBPRINT=$(echo \
+    | openssl s_client -servername ${GITHUB_OIDC_HOST} -showcerts -connect ${GITHUB_OIDC_HOST}:443 2>&- \
+    | tac \
+    | sed -n '/-----END CERTIFICATE-----/,/-----BEGIN CERTIFICATE-----/p; /-----BEGIN CERTIFICATE-----/q' \
+    | tac \
+    | openssl x509 -fingerprint -noout | sed 's/://g' | awk -F= '{print tolower($2)}')
+
+echo "$THUMBPRINT"

--- a/infrastructure/components/terraform/github-oidc-provider/variables.tf
+++ b/infrastructure/components/terraform/github-oidc-provider/variables.tf
@@ -1,0 +1,15 @@
+variable "aws_profile_name" {
+  description = "The name of the AWS profile to use"
+  type        = string
+}
+
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "thumbprint_list" {
+  type        = list(string)
+  description = "List of OIDC provider certificate thumbprints"
+  default     = ["6938fd4d98bab03faadb97b34396831e3780aea1", "1c58a3a8518e8759bf075b76b750d4f2df264fcd"]
+}

--- a/infrastructure/components/terraform/github-oidc-provider/versions.tf
+++ b/infrastructure/components/terraform/github-oidc-provider/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.22.0"
+    }
+  }
+}


### PR DESCRIPTION
### Description

* Setting up GitHub OIDC provider.

### Why

* JIRA Ticket: [DEV-](https://jira.example.com/browse/DEV-)
* To grant GitHub Actions permission to assume an IAM role that will have the permissions to push images to ECR's repositories.

### Diagram
```mermaid
graph TD
  subgraph GitHub Actions
    GA[GitHub Actions Workflow]
  end

  subgraph AWS
    subgraph Region - us-east-1
      ECR[ECR Repository]
    end
    OIDC[OIDC Provider]
    IAM[IAM Role]
  end

  GA -->|assumes role via| OIDC
  OIDC -->|grants access| IAM
  IAM -->|has permissions| ECR
  GA -->|pushes images to| ECR
  ```

### Reference

* [GitHub OIDC Provider Module by Cloud Posse](https://github.com/cloudposse/terraform-aws-components/tree/1.474.0/modules/github-oidc-provider)
* [YouTube Video: Setting up GitHub OIDC Provider](https://youtube.com/watch?v=aOoRaVuh8Lc)
* [Dev.to Article: AWS SSO and GitHub Setup](https://dev.to/aws-builders/aws-sso-github-setup-35ld)
* [GitHub docs](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)