### PR TITLE
feat(infra) Create GitHub Action IAM Role

### DIFF
--- a/infrastructure/components/terraform/github-actions-iam-role/context.tf
+++ b/infrastructure/components/terraform/github-actions-iam-role/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/infrastructure/components/terraform/github-actions-iam-role/main.tf
+++ b/infrastructure/components/terraform/github-actions-iam-role/main.tf
@@ -1,0 +1,41 @@
+locals {
+  github_repos_sub = [
+    for repo_name in var.trusted_github_repo_names : (
+      format("repo:%s/%s:*", var.trusted_github_org, repo_name)
+    )
+  ]
+}
+
+module "github_actions_iam_role" {
+  source = "cloudposse/iam-role/aws"
+  version     = "0.19.0"
+
+  enabled   = module.this.enabled
+  context   = module.this.context
+
+  role_description   = "IAM role with permissions to perform push on ECR repositories and EKS helm permissions"
+
+  principals = {
+    Federated = [one(module.github_oidc_provider[*].outputs.oidc_provider_arn)]
+  }
+
+  assume_role_actions = [
+    "sts:AssumeRoleWithWebIdentity"
+  ]
+
+  assume_role_conditions = [
+    {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    },
+    {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = local.github_repos_sub
+    },
+  ]
+
+  # The required permissions for this role will be defined in the ECR and EKS modules.
+  policy_document_count = 0
+}

--- a/infrastructure/components/terraform/github-actions-iam-role/outputs.tf
+++ b/infrastructure/components/terraform/github-actions-iam-role/outputs.tf
@@ -1,0 +1,24 @@
+output "name" {
+  description = "The name of the IAM role created"
+  value       = module.github_actions_iam_role.name
+}
+
+output "id" {
+  description = "The stable and unique string identifying the role"
+  value       = module.github_actions_iam_role.id
+}
+
+output "arn" {
+  description = "The Amazon Resource Name (ARN) specifying the role"
+  value       = module.github_actions_iam_role.arn
+}
+
+output "policy" {
+  description = "Role policy document in json format. Outputs always, independent of `enabled` variable"
+  value       = module.github_actions_iam_role.policy
+}
+
+output "instance_profile" {
+  description = "Name of the ec2 profile (if enabled)"
+  value       = module.github_actions_iam_role.instance_profile
+}

--- a/infrastructure/components/terraform/github-actions-iam-role/providers.tf
+++ b/infrastructure/components/terraform/github-actions-iam-role/providers.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+    region = var.region
+    profile = var.aws_profile_name
+
+    default_tags {
+        tags = module.this.tags
+    }
+}

--- a/infrastructure/components/terraform/github-actions-iam-role/remote-state.tf
+++ b/infrastructure/components/terraform/github-actions-iam-role/remote-state.tf
@@ -1,0 +1,22 @@
+module "github_oidc_provider" {
+  count = module.this.enabled ? 1 : 0
+
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  component = "github-oidc-provider"
+  environment = "gbl"
+
+  atmos_cli_config_path = "../../../"
+
+  # privileged = var.privileged
+
+  # ignore_errors = true
+
+  defaults = {
+    # TODO: below value is hardcoded this defaults has to be removed.
+    oidc_provider_arn = "arn:aws:iam::270340338153:oidc-provider/token.actions.githubusercontent.com"
+  }
+
+  context = module.this.context
+}

--- a/infrastructure/components/terraform/github-actions-iam-role/variables.tf
+++ b/infrastructure/components/terraform/github-actions-iam-role/variables.tf
@@ -1,0 +1,19 @@
+variable "aws_profile_name" {
+  description = "The name of the AWS profile to use"
+  type        = string
+}
+
+variable "region" {
+  description = "The AWS region to deploy resources"
+  type        = string
+}
+
+variable "trusted_github_repo_names" {
+  description = "A list of GitHub repository names allowed to access this role."
+  type        = list(string)
+}
+
+variable "trusted_github_org" {
+  description = "The GitHub organization unqualified repos are assumed to belong to. Keeps `*` from meaning all orgs and all repos."
+  type        = string
+}

--- a/infrastructure/components/terraform/github-actions-iam-role/versions.tf
+++ b/infrastructure/components/terraform/github-actions-iam-role/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.22.0"
+    }
+  }
+}

--- a/infrastructure/stacks/catalog/github-actions-iam-role.yaml
+++ b/infrastructure/stacks/catalog/github-actions-iam-role.yaml
@@ -1,0 +1,10 @@
+components:
+  terraform:
+    github-actions-iam-role:
+      metadata:
+        component: github-actions-iam-role
+      vars:
+        name: github-actions-iam-role
+        trusted_github_org: franciscoprin
+        trusted_github_repo_names:
+         - parrot-project

--- a/infrastructure/stacks/deploy/gbl-experiments.yaml
+++ b/infrastructure/stacks/deploy/gbl-experiments.yaml
@@ -6,6 +6,7 @@ vars:
 
 import:
   - catalog/github-oidc-provider
+  - catalog/github-actions-iam-role
 
 components:
   terraform:


### PR DESCRIPTION
### Description

* Creating a Terraform component that will be responsible for creating a GitHub IAM role.

### Why

* JIRA Ticket: [DEV-](https://jira.example.com/browse/DEV-)
* By creating a centralized role, it can be reused later by the ECR and EKS components to grant the necessary permissions so that GHA can push images to ECR and perform CRUD operations on Kubernetes manifests.
