### PR TITLE
Refactor/Use GitHub Actions IAM role for ECR

### DIFF
--- a/.github/workflows/challenge-devops-build.yml
+++ b/.github/workflows/challenge-devops-build.yml
@@ -5,9 +5,9 @@ name: Build Pipeline
 on:
   push:
     branches:
-      # - main
-      # For testing purposes push in any branch
-      - "**"
+      - main
+      # # For testing purposes push in any branch
+      # - "**"
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/challenge-devops-build.yml
+++ b/.github/workflows/challenge-devops-build.yml
@@ -5,9 +5,9 @@ name: Build Pipeline
 on:
   push:
     branches:
-      - main
-      # # For testing purposes push in any branch
-      # - "**"
+      # - main
+      # For testing purposes push in any branch
+      - "**"
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -20,7 +20,7 @@ jobs:
     env:
       APP_NAME: challenge-devops
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-      AWS_ASSUME_ROLE_NAME: ue1-experiments-github-actions-ecr-push-role
+      AWS_ASSUME_ROLE_NAME: gbl-experiments-github-actions-iam-role
       AWS_REGION: us-east-1
 
     steps:

--- a/infrastructure/components/terraform/ecr/iam.tf
+++ b/infrastructure/components/terraform/ecr/iam.tf
@@ -79,3 +79,15 @@ module "role_github_action_ecr_push" {
     data.aws_iam_policy_document.ecr_push_access.json,
   ]
 }
+
+# Grant GitHub Actions IAM role access to push Docker images to ECR.
+resource "aws_iam_policy" "ecr_push_access" {
+  name        = module.this.id
+  description = "Allow ECR PushAccess"
+  policy      = data.aws_iam_policy_document.ecr_push_access.json
+}
+
+resource "aws_iam_role_policy_attachment" "example_role_policy_attachment" {
+  role       = one(module.github_actions_iam_role[*].outputs.name)
+  policy_arn = aws_iam_policy.ecr_push_access.arn
+}

--- a/infrastructure/components/terraform/ecr/remote-state.tf
+++ b/infrastructure/components/terraform/ecr/remote-state.tf
@@ -4,10 +4,8 @@ module "github_oidc_provider" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.5.0"
 
-  stack  = "gbl-experiments"
   component = "github-oidc-provider"
   environment = "gbl"
-  stage = "experiments"
 
   atmos_cli_config_path = "../../../"
 
@@ -18,6 +16,29 @@ module "github_oidc_provider" {
   defaults = {
     # TODO: below value is hardcoded this defaults has to be removed.
     oidc_provider_arn = "arn:aws:iam::270340338153:oidc-provider/token.actions.githubusercontent.com"
+  }
+
+  context = module.this.context
+}
+
+module "github_actions_iam_role" {
+  count = module.this.enabled ? 1 : 0
+
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  component = "github-oidc-provider"
+  environment = "gbl"
+
+  atmos_cli_config_path = "../../../"
+
+  # privileged = var.privileged
+
+  # ignore_errors = true
+
+  defaults = {
+    # TODO: below value is hardcoded this defaults has to be removed.
+    name = "gbl-experiments-github-actions-iam-role"
   }
 
   context = module.this.context


### PR DESCRIPTION
### Description

* Use the `github-actions-iam-role` Terraform component for ECR.

### Why

* JIRA Ticket: [DEV-](https://jira.example.com/browse/DEV-)
* To centralize the creation of a single role which can be imported into multiple modules (i.e., ECR & EKS) to grant it the necessary permissions so GitHub Actions workflows can deploy the respective source code.

### Reference

* [PR that created the `github-actions-iam-role` Terraform component](https://github.com/franciscoprin/parrot-project/pull/10)
