### PR TITLE
feat(infra) Setup EKS ALB Controller

### DIFF
--- a/infrastructure/components/terraform/eks/alb-controller/context.tf
+++ b/infrastructure/components/terraform/eks/alb-controller/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/infrastructure/components/terraform/eks/alb-controller/distributed-iam-policy.tf
+++ b/infrastructure/components/terraform/eks/alb-controller/distributed-iam-policy.tf
@@ -1,0 +1,263 @@
+
+# The kubernetes-sigs/aws-load-balancer-controller/ project distributes the
+# AWS IAM policy that is required for the AWS Load Balancer Controller as a JSON
+# download at https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v<VERSION>/docs/install/iam_policy.json
+# See https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.6/deploy/installation/#option-a-recommended-iam-roles-for-service-accounts-irsa for details.
+
+# We could directly use the URL to download and install the policy at runtime,
+# via the cloudposse/helm-release/aws module's ` iam_source_json_url` input,
+# but that lacks transparency and auditability. It also does not give us a chance
+# to make changes in response to bugs, such as
+# https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2692#issuecomment-1426242236
+#
+# So we download the policy and insert it here as a local variable.
+
+locals {
+  # To update, just replace everything between the two "EOT"s with the contents of the downloaded JSON file.
+  # Below is the policy as of version 2.6.0, downloaded from
+  # https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.6.0/docs/install/iam_policy.json
+  # This policy is for the `aws` partition. Override overridable_distributed_iam_policy for other partitions.
+  overridable_distributed_iam_policy = <<EOT
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOT
+}

--- a/infrastructure/components/terraform/eks/alb-controller/main.tf
+++ b/infrastructure/components/terraform/eks/alb-controller/main.tf
@@ -1,0 +1,70 @@
+module "alb_controller" {
+  source  = "cloudposse/helm-release/aws"
+  version = "0.10.0"
+
+  chart           = var.chart
+  repository      = var.chart_repository
+  description     = var.chart_description
+  chart_version   = var.chart_version
+  wait            = true # required for installing IngressClassParams
+  atomic          = var.atomic
+  cleanup_on_fail = var.cleanup_on_fail
+  timeout         = var.timeout
+
+  create_namespace_with_kubernetes = var.create_namespace
+  kubernetes_namespace             = var.kubernetes_namespace
+  kubernetes_namespace_labels      = merge(module.this.tags, { name = var.kubernetes_namespace })
+
+  eks_cluster_oidc_issuer_url = replace(module.eks.outputs.eks_cluster_identity_oidc_issuer, "https://", "")
+
+  service_account_name      = module.this.name
+  service_account_namespace = var.kubernetes_namespace
+
+  iam_role_enabled = true
+  # See distributed-iam-policy.tf
+  iam_source_policy_documents = [local.overridable_distributed_iam_policy]
+
+  values = compact([
+    # standard k8s object settings
+    yamlencode({
+      fullnameOverride = module.this.name,
+      serviceAccount = {
+        name = module.this.name
+      },
+      resources = var.resources
+      rbac = {
+        create = var.rbac_enabled
+      }
+    }),
+    # alb-controller-specific values
+    yamlencode({
+      aws = {
+        region = var.region
+      }
+      clusterName                = module.eks.outputs.eks_cluster_id
+      createIngressClassResource = var.default_ingress_enabled
+      ingressClass               = var.default_ingress_class_name
+      ingressClassParams = {
+        name   = var.default_ingress_class_name
+        create = var.default_ingress_enabled
+        spec = {
+          group = {
+            name = var.default_ingress_group
+          }
+          scheme                 = var.default_ingress_scheme
+          ipAddressType          = var.default_ingress_ip_address_type
+          tags                   = [for k, v in merge(module.this.tags, var.default_ingress_additional_tags) : { key = k, value = v }]
+          loadBalancerAttributes = var.default_ingress_load_balancer_attributes
+        }
+      }
+      ingressClassConfig = {
+        default = var.default_ingress_enabled
+      }
+      defaultTags = module.this.tags
+    }),
+    # additional values
+    yamlencode(var.chart_values)
+  ])
+
+  context = module.this.context
+}

--- a/infrastructure/components/terraform/eks/alb-controller/outputs.tf
+++ b/infrastructure/components/terraform/eks/alb-controller/outputs.tf
@@ -1,0 +1,4 @@
+output "metadata" {
+  value       = module.alb_controller.metadata
+  description = "Block status of the deployed release"
+}

--- a/infrastructure/components/terraform/eks/alb-controller/provider-helm.tf
+++ b/infrastructure/components/terraform/eks/alb-controller/provider-helm.tf
@@ -1,0 +1,207 @@
+##################
+#
+# This file is a drop-in to provide a helm provider.
+#
+# It depends on 2 standard Cloud Posse data source modules to be already
+# defined in the same component:
+#
+#   1. module.iam_roles to provide the AWS profile or Role ARN to use to access the cluster
+#   2. module.eks to provide the EKS cluster information
+#
+# All the following variables are just about configuring the Kubernetes provider
+# to be able to modify EKS cluster. The reason there are so many options is
+# because at various times, each one of them has had problems, so we give you a choice.
+#
+# The reason there are so many "enabled" inputs rather than automatically
+# detecting whether or not they are enabled based on the value of the input
+# is that any logic based on input values requires the values to be known during
+# the "plan" phase of Terraform, and often they are not, which causes problems.
+#
+variable "kubeconfig_file_enabled" {
+  type        = bool
+  default     = false
+  description = "If `true`, configure the Kubernetes provider with `kubeconfig_file` and use that kubeconfig file for authenticating to the EKS cluster"
+  nullable    = false
+}
+
+variable "kubeconfig_file" {
+  type        = string
+  default     = ""
+  description = "The Kubernetes provider `config_path` setting to use when `kubeconfig_file_enabled` is `true`"
+  nullable    = false
+}
+
+variable "kubeconfig_context" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+    Context to choose from the Kubernetes config file.
+    If supplied, `kubeconfig_context_format` will be ignored.
+    EOT
+  nullable    = false
+}
+
+variable "kubeconfig_context_format" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+    A format string to use for creating the `kubectl` context name when
+    `kubeconfig_file_enabled` is `true` and `kubeconfig_context` is not supplied.
+    Must include a single `%s` which will be replaced with the cluster name.
+    EOT
+  nullable    = false
+}
+
+variable "kube_data_auth_enabled" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.
+    Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`.
+    EOT
+  nullable    = false
+}
+
+variable "kube_exec_auth_enabled" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+    If `true`, use the Kubernetes provider `exec` feature to execute `aws eks get-token` to authenticate to the EKS cluster.
+    Disabled by `kubeconfig_file_enabled`, overrides `kube_data_auth_enabled`.
+    EOT
+  nullable    = false
+}
+
+variable "kube_exec_auth_role_arn" {
+  type        = string
+  default     = ""
+  description = "The role ARN for `aws eks get-token` to use"
+  nullable    = false
+}
+
+variable "kube_exec_auth_role_arn_enabled" {
+  type        = bool
+  default     = true
+  description = "If `true`, pass `kube_exec_auth_role_arn` as the role ARN to `aws eks get-token`"
+  nullable    = false
+}
+
+variable "kube_exec_auth_aws_profile" {
+  type        = string
+  default     = ""
+  description = "The AWS config profile for `aws eks get-token` to use"
+  nullable    = false
+}
+
+variable "kube_exec_auth_aws_profile_enabled" {
+  type        = bool
+  default     = false
+  description = "If `true`, pass `kube_exec_auth_aws_profile` as the `profile` to `aws eks get-token`"
+  nullable    = false
+}
+
+variable "kubeconfig_exec_auth_api_version" {
+  type        = string
+  default     = "client.authentication.k8s.io/v1beta1"
+  description = "The Kubernetes API version of the credentials returned by the `exec` auth plugin"
+  nullable    = false
+}
+
+variable "helm_manifest_experiment_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable storing of the rendered manifest for helm_release so the full diff of what is changing can been seen in the plan"
+  nullable    = false
+}
+
+locals {
+  kubeconfig_file_enabled = var.kubeconfig_file_enabled
+  kubeconfig_file         = local.kubeconfig_file_enabled ? var.kubeconfig_file : ""
+  kubeconfig_context = !local.kubeconfig_file_enabled ? "" : (
+    length(var.kubeconfig_context) != 0 ? var.kubeconfig_context : (
+      length(var.kubeconfig_context_format) != 0 ? format(var.kubeconfig_context_format, local.eks_cluster_id) : ""
+    )
+  )
+
+  kube_exec_auth_enabled = local.kubeconfig_file_enabled ? false : var.kube_exec_auth_enabled
+  kube_data_auth_enabled = local.kube_exec_auth_enabled ? false : var.kube_data_auth_enabled
+
+  # Eventually we might try to get this from an environment variable
+  kubeconfig_exec_auth_api_version = var.kubeconfig_exec_auth_api_version
+
+  exec_profile = local.kube_exec_auth_enabled && var.kube_exec_auth_aws_profile_enabled ? [
+    "--profile", var.kube_exec_auth_aws_profile
+  ] : []
+
+  # kube_exec_auth_role_arn = coalesce(var.kube_exec_auth_role_arn, module.iam_roles.terraform_role_arn)
+  # exec_role = local.kube_exec_auth_enabled && var.kube_exec_auth_role_arn_enabled ? [
+  #   "--role-arn", local.kube_exec_auth_role_arn
+  # ] : []
+
+  # Provide dummy configuration for the case where the EKS cluster is not available.
+  certificate_authority_data = local.kubeconfig_file_enabled ? null : try(module.eks.outputs.eks_cluster_certificate_authority_data, null)
+  cluster_ca_certificate     = local.kubeconfig_file_enabled ? null : try(base64decode(local.certificate_authority_data), null)
+  # Use coalesce+try to handle both the case where the output is missing and the case where it is empty.
+  eks_cluster_id       = coalesce(try(module.eks.outputs.eks_cluster_id, ""), "missing")
+  eks_cluster_endpoint = local.kubeconfig_file_enabled ? null : try(module.eks.outputs.eks_cluster_endpoint, "")
+}
+
+data "aws_eks_cluster_auth" "eks" {
+  count = local.kube_data_auth_enabled ? 1 : 0
+  name  = local.eks_cluster_id
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.eks_cluster_endpoint
+    cluster_ca_certificate = local.cluster_ca_certificate
+    token                  = local.kube_data_auth_enabled ? one(data.aws_eks_cluster_auth.eks[*].token) : null
+    # It is too confusing to allow the Kubernetes provider to use environment variables to set authentication
+    # in this module because we have so many options, so we override environment variables like `KUBE_CONFIG_PATH`
+    # in all cases. People can still use environment variables by setting TF_VAR_kubeconfig_file.
+    config_path    = local.kubeconfig_file
+    config_context = local.kubeconfig_context
+
+    dynamic "exec" {
+      for_each = local.kube_exec_auth_enabled && local.certificate_authority_data != null ? ["exec"] : []
+      content {
+        api_version = local.kubeconfig_exec_auth_api_version
+        command     = "aws"
+        # args = concat(local.exec_profile, [
+        #   "eks", "get-token", "--cluster-name", local.eks_cluster_id
+        # ], local.exec_role)
+        args = concat(local.exec_profile, [
+          "eks", "get-token", "--cluster-name", local.eks_cluster_id
+        ])
+      }
+    }
+  }
+  experiments {
+    manifest = var.helm_manifest_experiment_enabled && module.this.enabled
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.eks_cluster_endpoint
+  cluster_ca_certificate = local.cluster_ca_certificate
+  token                  = local.kube_data_auth_enabled ? one(data.aws_eks_cluster_auth.eks[*].token) : null
+  # # It is too confusing to allow the Kubernetes provider to use environment variables to set authentication
+  # # in this module because we have so many options, so we override environment variables like `KUBE_CONFIG_PATH`
+  # # in all cases. People can still use environment variables by setting TF_VAR_kubeconfig_file.
+  # config_path    = local.kubeconfig_file
+  # config_context = local.kubeconfig_context
+
+  dynamic "exec" {
+    for_each = local.kube_exec_auth_enabled && local.certificate_authority_data != null ? ["exec"] : []
+    content {
+      api_version = local.kubeconfig_exec_auth_api_version
+      command     = "aws"
+      # args = concat(local.exec_profile, [
+      #   "eks", "get-token", "--cluster-name", local.eks_cluster_id
+      # ], local.exec_role)
+      args = concat(local.exec_profile, [
+        "eks", "get-token", "--cluster-name", local.eks_cluster_id
+      ])
+    }
+  }
+}

--- a/infrastructure/components/terraform/eks/alb-controller/providers.tf
+++ b/infrastructure/components/terraform/eks/alb-controller/providers.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+    region = var.region
+    profile = var.aws_profile_name
+
+    default_tags {
+        tags = module.this.tags
+    }
+}

--- a/infrastructure/components/terraform/eks/alb-controller/remote-state.tf
+++ b/infrastructure/components/terraform/eks/alb-controller/remote-state.tf
@@ -1,0 +1,10 @@
+module "eks" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  atmos_cli_config_path = "../../../../"
+
+  component = var.eks_component_name
+
+  context = module.this.context
+}

--- a/infrastructure/components/terraform/eks/alb-controller/variables.tf
+++ b/infrastructure/components/terraform/eks/alb-controller/variables.tf
@@ -1,0 +1,149 @@
+variable "aws_profile_name" {
+  description = "The name of the AWS profile to use"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS Region."
+  type        = string
+}
+
+variable "chart_description" {
+  type        = string
+  description = "Set release description attribute (visible in the history)."
+  default     = null
+}
+
+variable "chart" {
+  type        = string
+  description = "Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended."
+}
+
+variable "chart_repository" {
+  type        = string
+  description = "Repository URL where to locate the requested chart."
+}
+
+variable "chart_version" {
+  type        = string
+  description = "Specify the exact chart version to install. If this is not specified, the latest version is installed."
+  default     = null
+}
+
+variable "resources" {
+  type = object({
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  description = "The cpu and memory of the deployment's limits and requests."
+}
+
+variable "create_namespace" {
+  type        = bool
+  description = "Create the namespace if it does not yet exist. Defaults to `false`."
+  default     = null
+}
+
+variable "kubernetes_namespace" {
+  type        = string
+  description = "The namespace to install the release into."
+}
+
+variable "timeout" {
+  type        = number
+  description = "Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds"
+  default     = null
+}
+
+variable "cleanup_on_fail" {
+  type        = bool
+  description = "Allow deletion of new resources created in this upgrade when upgrade fails."
+  default     = true
+}
+
+variable "atomic" {
+  type        = bool
+  description = "If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used."
+  default     = true
+}
+
+variable "chart_values" {
+  type        = any
+  description = "Additional values to yamlencode as `helm_release` values."
+  default     = {}
+}
+
+variable "rbac_enabled" {
+  type        = bool
+  default     = true
+  description = "Service Account for pods."
+}
+
+variable "eks_component_name" {
+  type        = string
+  description = "The name of the eks component"
+  default     = "eks/cluster"
+}
+
+####### Configure default Ingress Class #######
+
+variable "default_ingress_enabled" {
+  type        = bool
+  description = "Set `true` to deploy a default IngressClass. There should only be one default per cluster."
+  default     = true
+}
+
+variable "default_ingress_class_name" {
+  type        = string
+  description = "Class name for default ingress"
+  default     = "default"
+}
+
+variable "default_ingress_group" {
+  type        = string
+  description = "Group name for default ingress"
+  default     = "common"
+}
+
+variable "default_ingress_scheme" {
+  type        = string
+  description = "Scheme for default ingress, one of `internet-facing` or `internal`."
+  default     = "internet-facing"
+
+  validation {
+    condition     = contains(["internet-facing", "internal"], var.default_ingress_scheme)
+    error_message = "The default ingress scheme must be one of `internet-facing` or `internal`."
+  }
+}
+
+variable "default_ingress_ip_address_type" {
+  type        = string
+  description = "IP address type for default ingress, one of `ipv4` or `dualstack`."
+  default     = "ipv4"
+
+  validation {
+    condition     = contains(["ipv4", "dualstack"], var.default_ingress_ip_address_type)
+    error_message = "The default ingress IP address type must be one of `ipv4` or `dualstack`."
+  }
+}
+
+variable "default_ingress_load_balancer_attributes" {
+  type        = list(object({ key = string, value = string }))
+  description = <<-EOT
+    A list of load balancer attributes to apply to the default ingress load balancer.
+    See [Load Balancer Attributes](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#load-balancer-attributes).
+    EOT
+  default     = []
+}
+
+variable "default_ingress_additional_tags" {
+  type        = map(string)
+  description = "Additional tags to apply to the ingress load balancer."
+  default     = {}
+}

--- a/infrastructure/components/terraform/eks/alb-controller/versions.tf
+++ b/infrastructure/components/terraform/eks/alb-controller/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.14.0, != 2.21.0"
+    }
+  }
+}

--- a/infrastructure/components/terraform/eks/cluster/providers.tf
+++ b/infrastructure/components/terraform/eks/cluster/providers.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+    region = var.region
+    profile = var.aws_profile_name
+
+    default_tags {
+        tags = module.this.tags
+    }
+}

--- a/infrastructure/stacks/catalog/eks/alb-controller.yaml
+++ b/infrastructure/stacks/catalog/eks/alb-controller.yaml
@@ -1,0 +1,44 @@
+components:
+  terraform:
+    eks/alb-controller:
+      vars:
+        chart: aws-load-balancer-controller
+        chart_repository: https://aws.github.io/eks-charts
+        # IMPORTANT: When updating the chart version, check to see if the IAM policy for the service account.
+        # needs to be updated, and if it does, update the policy in the `distributed-iam-policy.tf` file.
+        chart_version: "1.6.0"
+        create_namespace: true
+        kubernetes_namespace: alb-controller
+        # this feature causes inconsistent final plans
+        # see https://github.com/hashicorp/terraform-provider-helm/issues/711#issuecomment-836192991
+        helm_manifest_experiment_enabled: false
+
+        kube_data_auth_enabled: false
+        kube_exec_auth_enabled: true
+        kubeconfig_file_enabled: false
+        kube_exec_auth_aws_profile: experiments-admin
+        kube_exec_auth_aws_profile_enabled: true
+
+        default_ingress_class_name: default
+        default_ingress_group: common
+        default_ingress_ip_address_type: ipv4
+        default_ingress_scheme: internet-facing
+        # You can use `chart_values` to set any other chart options. Treat `chart_values` as the root of the doc.
+        #
+        # # For example
+        # ---
+        # chart_values:
+        #   enableShield: false
+        chart_values:
+          image:
+            repository: amazon/aws-alb-ingress-controller
+            tag: v2.4.5
+            pullPolicy: IfNotPresent
+
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"

--- a/infrastructure/stacks/deploy/ue1-experiments.yaml
+++ b/infrastructure/stacks/deploy/ue1-experiments.yaml
@@ -6,6 +6,8 @@ vars:
 
 import:
   - catalog/ecr
+  - catalog/eks/alb-controller
+  - catalog/eks/cluster
   - catalog/vpc
 
 components:


### PR DESCRIPTION
### Description

* Setting up the ALB controller 

### Why

* JIRA Ticket: [DEV-](https://jira.example.com/browse/DEV-)
* This module will be responsible for translating Kubernetes ingress annotations into AWS ALB, which will allow EKS Pods to be accessible through the internet.

### Reference

* [Cloud Posse ALB controller module](https://github.com/cloudposse/terraform-aws-components/tree/d12201d0affeffd14e5d47276934cfd4b91c2d15/modules/eks/alb-controller)
