### PR TITLE
feat(conf): Configure Django application for deployment

### DIFF
--- a/challenge-devops/Dockerfile
+++ b/challenge-devops/Dockerfile
@@ -20,7 +20,6 @@ COPY . /code/
 
 ENTRYPOINT ["/entrypoint"]
 
-# TODO: uncomment below and make the application work with gunicorn
-# # https://docs.djangoproject.com/en/5.0/howto/deployment/wsgi/gunicorn/
-# # AWS ALB works well with gunicorn: https://github.com/benoitc/gunicorn/issues/2568#issuecomment-827935102
-# CMD ["gunicorn", "--bind", "0.0.0.0:8000", "challenge.wsgi.application"]
+# https://docs.djangoproject.com/en/5.0/howto/deployment/wsgi/gunicorn/
+# AWS ALB works well with gunicorn: https://github.com/benoitc/gunicorn/issues/2568#issuecomment-827935102
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "challenge.wsgi"]

--- a/challenge-devops/challenge/settings.py
+++ b/challenge-devops/challenge/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 
 from pathlib import Path
 from environ import environ
+import os
 
 # Load env vars
 env = environ.Env()
@@ -131,3 +132,10 @@ REST_FRAMEWORK = {
 }
 
 from challenge.app_settings import * 
+
+STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'counters'),
+]

--- a/challenge-devops/challenge/urls.py
+++ b/challenge-devops/challenge/urls.py
@@ -15,8 +15,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf.urls.static import static
+from django.conf import settings
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/counters/', include('counters.urls', namespace='counters')),
-]
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/challenge-devops/docker-compose.yml
+++ b/challenge-devops/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     command: python manage.py runserver 0.0.0.0:8000
     env_file:
       - scripts/envs/app
+    environment:
+      CHAMBER_ENABLE: false 
     volumes:
       - .:/code
     ports:

--- a/challenge-devops/requirements.txt
+++ b/challenge-devops/requirements.txt
@@ -4,3 +4,4 @@ django-environ==0.4.5
 djangorestframework==3.11.0
 djangorestframework-camel-case==1.2.0
 factory_boy==2.12.0
+gunicorn==22.0.0


### PR DESCRIPTION
### Description

* Using Gunicorn rather than the Django development server.
* Creating configuration to collect static files.

### Why

* JIRA Ticket: [DEV-](https://jira.example.com/browse/DEV-)
* The Django development server (`runserver`) is designed for development and debugging. It's not optimized for performance, lacks security features, and isn't recommended for handling production traffic.
* Gunicorn is a production-grade WSGI HTTP server for Python web applications. It's designed to handle a large number of requests efficiently and securely.
* It is required to serve the application with Gunicorn, which by default doesn't collect or refresh static files (images, CSS, HTML, etc).

### Reference

* [Django Deployment Documentation](https://docs.djangoproject.com/en/5.0/howto/deployment/): Comprehensive guide on deploying Django applications.
* [Django Collectstatic Command](https://docs.djangoproject.com/en/5.0/ref/contrib/staticfiles/#django-admin-collectstatic): Detailed information on the `collectstatic` command and its usage.